### PR TITLE
Fix disable issues

### DIFF
--- a/src/xyz/fly/FlyXYZ.java
+++ b/src/xyz/fly/FlyXYZ.java
@@ -1,6 +1,7 @@
 package xyz.fly;
 
 import org.bukkit.ChatColor;
+import org.bukkit.GameMode;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -19,8 +20,10 @@ public class FlyXYZ extends JavaPlugin {
 
     @Override
     public void onDisable(){
-        for(Player p: this.players){
-            p.setAllowFlight(false);
+        for(Player p: this.getServer().getOnlinePlayers()){
+            if(p.getGameMode() != GameMode.CREATIVE && p.getGameMode() != GameMode.SPECTATOR){
+                p.setAllowFlight(false);
+			}
         }
     }
 


### PR DESCRIPTION
At the moment, the code looks like it has been written to automatically put out all people from fly mode on disable, however, the existing logic has its little flasa, it currently loops over an empty list of player, and there is no protection for people in creative and survival modes.

This PR attempts to fix this flaw, so the plugin can more easily be disabled on a real server